### PR TITLE
Fix payment status tampering vulnerability and add Suspected Fraud order handling

### DIFF
--- a/to_upload/Juspay/Payment/Controller/Adminhtml/Order/StatusSync.php
+++ b/to_upload/Juspay/Payment/Controller/Adminhtml/Order/StatusSync.php
@@ -4,45 +4,124 @@ namespace Juspay\Payment\Controller\Adminhtml\Order;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Sales\Api\OrderRepositoryInterface;
-use Juspay\Payment\Controller\Standard\JuspayPayment;
+use Magento\Sales\Model\OrderFactory;
+use Magento\Sales\Model\Service\InvoiceService;
+use Magento\Framework\DB\Transaction;
+use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
+use Juspay\Payment\Model\Config;
+use PaymentHandler\PaymentHandler;
+use PaymentHandler\PaymentHandlerConfig;
+
+require_once dirname( __DIR__, 2 ) . '/Standard/Includes/JuspayPaymentHandler.php';
 
 class StatusSync extends Action {
 	protected $orderRepository;
-	protected $juspayPayment;
+	protected $orderFactory;
+	protected $invoiceService;
+	protected $transaction;
+	protected $invoiceSender;
+	protected $config;
 
 	public function __construct(
 		Context $context,
 		OrderRepositoryInterface $orderRepository,
-		JuspayPayment $juspayPayment
+		OrderFactory $orderFactory,
+		InvoiceService $invoiceService,
+		Transaction $transaction,
+		InvoiceSender $invoiceSender,
+		Config $config
 	) {
 		parent::__construct( $context );
 		$this->orderRepository = $orderRepository;
-		$this->juspayPayment = $juspayPayment;
+		$this->orderFactory = $orderFactory;
+		$this->invoiceService = $invoiceService;
+		$this->transaction = $transaction;
+		$this->invoiceSender = $invoiceSender;
+		$this->config = $config;
 	}
 
-	/**
-	 * Execute action
-	 *
-	 * @throws \Magento\Framework\Exception\LocalizedException|\Exception
-	 */
 	public function execute() {
 		$orderId = $this->getRequest()->getParam( 'order_id' );
 		$resultRedirect = $this->resultRedirectFactory->create();
 
 		try {
 			$order = $this->orderRepository->get( $orderId );
-			$this->juspayPayment->manualStatusSync( $order );
+			$this->manualStatusSync( $order );
 			$this->messageManager->addSuccessMessage( __( 'Order Status Synced.' ) );
 		} catch (\Exception $e) {
 			$this->messageManager->addErrorMessage( $e->getMessage() );
 		}
 
-		return $resultRedirect->setPath( 'sales/order/view', [ 'order_id' => $order->getId() ] );
+		return $resultRedirect->setPath( 'sales/order/view', [ 'order_id' => $orderId ] );
 	}
 
-	/**
-	 * @return bool
-	 */
+	protected function manualStatusSync( $order ) {
+		$order_id = $order->getIncrementId();
+
+		$base_url = $this->config->getMode() === 'production'
+			? 'https://smartgateway.hdfc.bank.in'
+			: 'https://smartgateway.hdfcuat.bank.in';
+
+		$paymentHandlerConfig = PaymentHandlerConfig::getInstance()
+			->withInstance(
+				$this->config->getMerchantId(),
+				$this->config->getApiKey(),
+				$this->config->getClientId(),
+				$base_url,
+				$this->config->getResponseSecret(),
+			);
+		$paymentHandler = new PaymentHandler( $paymentHandlerConfig, $this->orderFactory );
+
+		$response = $paymentHandler->orderStatus( $order_id );
+		$this->addOrderNote( $order_id, 'Synced Payment Status : ' . $response['status'] );
+		$payment = $order->getPayment();
+		$statusParams = [ "order_id" => $order_id, "status" => $response['status'] ];
+
+		$paymentHandler->postProcessing( $order, $payment, $statusParams );
+
+		if ( $response['status'] == 'CHARGED' || $response['status'] == 'COD_INITIATED' ) {
+			$this->createInvoice( $order_id );
+			$this->addOrderNote( $order_id, "Payment successful - Order Id: " . $order_id );
+			$paymentMethod = $response['payment_method'];
+			$paymentMethodType = $response['payment_method_type'];
+			$this->addOrderNote( $order_id, "Payment Method : $paymentMethod ($paymentMethodType)" );
+		}
+	}
+
+	protected function createInvoice( $orderId ) {
+		try {
+			$order = $this->orderFactory->create()->loadByIncrementId( $orderId );
+		} catch (\Exception $e) {
+			$this->addOrderNote( $orderId, "Error loading order with ID $orderId: " . $e->getMessage() );
+			return;
+		}
+		if ( $order->canInvoice() ) {
+			$invoice = $this->invoiceService->prepareInvoice( $order );
+			$invoice->setTransactionId( $orderId );
+			$invoice->setRequestedCaptureCase( \Magento\Sales\Model\Order\Invoice::CAPTURE_OFFLINE );
+			$invoice->register();
+			$invoice->getOrder()->setCustomerNoteNotify( false );
+			$invoice->getOrder()->setIsInProcess( true );
+			$invoice->save();
+			$transactionSave = $this->transaction->addObject( $invoice )->addObject( $invoice->getOrder() );
+			$transactionSave->save();
+
+			$this->invoiceSender->send( $invoice );
+			$invoice->setEmailSent( true );
+			$invoice->save();
+
+			$this->addOrderNote( $orderId, 'Automatically INVOICED.' );
+		} else {
+			$this->addOrderNote( $orderId, "Order with ID $orderId cannot be invoiced." );
+		}
+	}
+
+	protected function addOrderNote( $order_id, $comment, $isCustomerNotified = false ) {
+		$jpOrder = $this->orderFactory->create()->loadByIncrementId( $order_id );
+		$jpOrder->addCommentToStatusHistory( $comment, $isCustomerNotified );
+		$jpOrder->save();
+	}
+
 	protected function _isAllowed() {
 		return true;
 	}

--- a/to_upload/Juspay/Payment/Controller/Standard/Includes/JuspayPaymentHandler.php
+++ b/to_upload/Juspay/Payment/Controller/Standard/Includes/JuspayPaymentHandler.php
@@ -46,12 +46,17 @@ class PaymentHandler {
 		\Magento\Framework\DataObject $payment, $response ) {
 
 		if ( in_array( $order->getStatus(), [ 'processing', 'complete', 'closed', 'canceled' ] ) ) {
-			$this->logger->info( "postProcessing skipped: Order {$order->getIncrementId()} already in terminal state." );
 			return;
 		}
 
 		$payment->setTransactionId( $response['order_id'] );
 		$payment->setTransactionAdditionalInfo( 'status_message', $response['status'] );
+
+		// Clear fraud detection flags if order was in Suspected Fraud state
+   		 if ( $response['status'] === 'CHARGED' || $response['status'] === 'COD_INITIATED' ) {
+    	    $payment->setIsFraudDetected( false );
+    	    $payment->setIsTransactionPending( false );
+    	}
 
 		switch ( $response['status'] ) {
 			case "CHARGED":
@@ -73,7 +78,7 @@ class PaymentHandler {
 				break;
 		}
 		$order->save();
-		$payment->place();
+		$payment->save();
 	}
 
 	/**

--- a/to_upload/Juspay/Payment/Controller/Standard/Response.php
+++ b/to_upload/Juspay/Payment/Controller/Standard/Response.php
@@ -52,13 +52,14 @@ class Response extends \Juspay\Payment\Controller\Standard\JuspayPayment {
 
 
 					if ( $status != 'NEW' ) {
-						$this->paymentHandler->postProcessing( $order, $payment, $params );
+						$verifiedResponse = [ 'order_id' => $params['order_id'], 'status' => $status ];
+						$this->paymentHandler->postProcessing( $order, $payment, $verifiedResponse );
 					}
 					$order = $this->getOrderByIncrementId( $params['order_id'] );
 
 					if ( $status == 'CHARGED' || $status == 'COD_INITIATED' ) {
 
-						if ( $order->getStatus() == 'pending_payment' || $order->getStatus() == 'pending' ) {
+						if ( in_array( $order->getStatus(), [ 'pending_payment', 'pending', 'fraud' ] ) ) {
 							$this->_createInvoice( $params['order_id'] );
 						}
 						$order->setCanSendNewEmailFlag( true );
@@ -88,7 +89,7 @@ class Response extends \Juspay\Payment\Controller\Standard\JuspayPayment {
 						}
 					}
 
-					$orderNote = 'Transaction Completed. Order Status: ' . $params['status'];
+					$orderNote = 'Transaction Completed. Order Status: ' . $status;
 					$this->addOrderNote( $params['order_id'], $orderNote, true );
 
 				} else {
@@ -112,6 +113,14 @@ class Response extends \Juspay\Payment\Controller\Standard\JuspayPayment {
 	}
 
 	protected function get_order_status( $params ) {
+		$status = strtoupper( trim( (string) ( $params['status'] ?? '' ) ) );
+        $signature = trim( (string) ( $params['signature'] ?? '' ) );
+
+        if ( $status === 'NEW' && $signature === '' ) {
+            $this->addOrderNote( $params['order_id'], 'No payment attempt detected (status NEW without signature). Validating status via Order Status API.' );
+            $order = $this->paymentHandler->orderStatus( $params["order_id"] );
+            return $order['status'];
+        }
 		if ( $this->paymentHandler->validateHMAC_SHA256( $params ) === false ) {
 			$this->addOrderNote( $params['order_id'], "ValidationParams: " . json_encode( $params ) );
 			$orderNote = 'Signature verification failed. Ensure that the \'Response Key\' is properly configured in plugin settings.';
@@ -123,7 +132,7 @@ class Response extends \Juspay\Payment\Controller\Standard\JuspayPayment {
 			return $order['status'];
 		}
 		$order = $this->paymentHandler->orderStatus( $params["order_id"] );
-		return $params['status'];
+		return $order['status'];
 	}
 
 	protected function get_status_message( $order ) {

--- a/to_upload/Juspay/Payment/Controller/Standard/Webhook.php
+++ b/to_upload/Juspay/Payment/Controller/Standard/Webhook.php
@@ -57,10 +57,13 @@ class Webhook extends \Juspay\Payment\Controller\Standard\JuspayPayment {
 		$order = $this->getOrderByIncrementId( $order_id );
 
 		if ( $order ) {
-			if ( $order->getStatus() == 'pending_payment' || $order->getStatus() == 'pending' ) {
+			// Allow processing for pending, pending_payment, and fraud (Suspected Fraud) orders
+			$processableStatuses = [ 'pending_payment', 'pending', 'fraud' ];
+			if ( in_array( $order->getStatus(), $processableStatuses ) ) {
 				$this->addOrderNote( $order_id, "SmartGateway payment successful (via SmartGateway Webhook)" );
 				$payment = $order->getPayment();
 				$params['txn_id'] = $params['content']['order']['txn_uuid'];
+				// Fraud flag clearing is handled inside postProcessing()
 				$paymentMethod->postProcessing( $order, $payment, $params );
 			} else {
 				$this->addOrderNote( $order_id, "Order Status: " . $order->getStatus() );

--- a/to_upload/Juspay/Payment/Model/PaymentMethod.php
+++ b/to_upload/Juspay/Payment/Model/PaymentMethod.php
@@ -22,8 +22,11 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod {
 	 * @var string
 	 */
 	protected $_code = 'smartgateway';
-	protected $_isGateway = false;
+	protected $_isGateway = true;
 	protected $_isOffline = false;
+	protected $_isInitializeNeeded = true;
+	protected $_canAuthorize = false;
+	protected $_canCapture = false;
 	protected $helper;
 	protected $logger;
 	protected $_minAmount = null;
@@ -326,6 +329,22 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod {
 	}
 
 
+	/**
+	 * Initialize payment method — called during quoteManagement->submit().
+	 * Sets the order to pending_payment state to prevent Magento's default
+	 * state handling from marking the order as "Suspected Fraud".
+	 *
+	 * @param string $paymentAction
+	 * @param \Magento\Framework\DataObject $stateObject
+	 * @return $this
+	 */
+	public function initialize( $paymentAction, $stateObject ) {
+		$stateObject->setState( Order::STATE_PENDING_PAYMENT );
+		$stateObject->setStatus( Order::STATE_PENDING_PAYMENT );
+		$stateObject->setIsNotified( false );
+		return $this;
+	}
+
 	public function getConfig( $key ) {
 		return $this->getConfigData( $key );
 	}
@@ -339,11 +358,18 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod {
 	public function postProcessing( \Magento\Sales\Model\Order $order, \Magento\Framework\DataObject $payment, $response ) {
 
 		if ( in_array( $order->getStatus(), [ 'processing', 'complete', 'closed', 'canceled' ] ) ) {
-			$this->logger->info( "postProcessing skipped: Order {$order->getIncrementId()} already in terminal state." );
+			$this->plog->info( "postProcessing skipped: Order {$order->getIncrementId()} already in terminal state." );
 			return;
 		}
 		try {
 			$order_id = $order->getIncrementId();
+
+			// Clear fraud detection flags if order was in Suspected Fraud state
+			if ( $order->getStatus() === 'fraud' || $order->getState() === Order::STATE_PAYMENT_REVIEW ) {
+				$payment->setIsFraudDetected( false );
+				$payment->setIsTransactionPending( false );
+				$this->addOrderNote( $order_id, 'Clearing Suspected Fraud flag — payment confirmed by gateway.' );
+			}
 
 			$order->setState( Order::STATE_PROCESSING );
 			$order_status = $order->getConfig()->getStateDefaultStatus( Order::STATE_PROCESSING );
@@ -387,7 +413,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod {
 			$payment->setTransactionId( $order_id );
 			$payment->setTransactionAdditionalInfo( 'status_message', $order_status );
 			$payment->setIsTransactionClosed( 0 );
-			$payment->place();
+			$payment->save();
 
 		} catch (Exception $e) {
 			$this->addOrderNote( $order_id, "Webhook PostProcessing Error: ." . $e->getMessage() );

--- a/to_upload/Juspay/Payment/Plugin/PreventOrderEmailPlugin.php
+++ b/to_upload/Juspay/Payment/Plugin/PreventOrderEmailPlugin.php
@@ -4,7 +4,6 @@ namespace Juspay\Payment\Plugin;
 
 use Juspay\Payment\Model\Config;
 use Magento\Sales\Model\Order;
-use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Psr\Log\LoggerInterface;
 
 class PreventOrderEmailPlugin {
@@ -17,31 +16,71 @@ class PreventOrderEmailPlugin {
 	}
 
 	/**
-	 * Prevent order email sending for Juspay pending payments
+	 * Prevent order/invoice email sending for Juspay pending payments.
+	 * Works for OrderSender (receives Order) and InvoiceSender (receives Invoice).
 	 *
-	 * @param OrderSender $subject
-	 * @param Order $order
+	 * @param mixed $subject OrderSender or InvoiceSender
+	 * @param mixed $entity  Order or Invoice
 	 * @param bool $forceSyncMode
 	 * @return array
 	 */
-	public function beforeSend( OrderSender $subject, Order $order, $forceSyncMode = false ) {
+	public function beforeSend( $subject, $entity, $forceSyncMode = false ) {
 		if ( ! $this->config->isPluginEnabled() ) {
-			return [ $order, $forceSyncMode ];
+			return [ $entity, $forceSyncMode ];
 		}
-		// Check if this is a Juspay payment with pending status
-		if ( $this->shouldPreventEmail( $order ) ) {
-			$this->logger->info( 'Preventing order email for Juspay order: ' . $order->getIncrementId() );
 
-			// Set flags to prevent email
+		$order = $this->resolveOrder( $entity );
+		if ( ! $order ) {
+			return [ $entity, $forceSyncMode ];
+		}
+
+		if ( $this->shouldPreventEmail( $order ) ) {
+			$this->logger->info( 'Preventing email for Juspay order: ' . $order->getIncrementId() );
+
 			$order->setCanSendNewEmailFlag( false );
 			$order->setEmailSent( true );
 			$order->setIsCustomerNotified( false );
-
-			// Return false to prevent email sending
-			return [ null, false ]; // This will prevent the email from being sent
 		}
 
-		return [ $order, $forceSyncMode ];
+		// Always return the original entity to avoid TypeError from null argument
+		return [ $entity, $forceSyncMode ];
+	}
+
+	/**
+	 * After send - suppress result if email should have been prevented
+	 *
+	 * @param mixed $subject OrderSender or InvoiceSender
+	 * @param bool $result
+	 * @param mixed $entity Order or Invoice
+	 * @return bool
+	 */
+	public function afterSend( $subject, $result, $entity ) {
+		if ( ! $this->config->isPluginEnabled() ) {
+			return $result;
+		}
+
+		$order = $this->resolveOrder( $entity );
+		if ( $order && $this->shouldPreventEmail( $order ) ) {
+			return false;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Resolve Order object from either an Order or Invoice instance.
+	 *
+	 * @param mixed $entity
+	 * @return Order|null
+	 */
+	private function resolveOrder( $entity ) {
+		if ( $entity instanceof Order ) {
+			return $entity;
+		}
+		if ( $entity instanceof \Magento\Sales\Model\Order\Invoice && $entity->getOrder() ) {
+			return $entity->getOrder();
+		}
+		return null;
 	}
 
 	/**
@@ -51,7 +90,6 @@ class PreventOrderEmailPlugin {
 	 * @return bool
 	 */
 	private function shouldPreventEmail( Order $order ) {
-		// Check multiple conditions
 		if ( $order->getData( 'juspay_payment_pending' ) ) {
 			return true;
 		}
@@ -61,28 +99,11 @@ class PreventOrderEmailPlugin {
 		}
 
 		if ( $order->getPayment() && $order->getPayment()->getMethod() === 'smartgateway' ) {
-			// Check if order is still in pending payment state
 			if ( $order->getState() === Order::STATE_PENDING_PAYMENT ) {
 				return true;
 			}
 		}
 
 		return false;
-	}
-
-	/**
-	 * After send - log if email was sent despite prevention attempts
-	 *
-	 * @param OrderSender $subject
-	 * @param bool $result
-	 * @param Order $order
-	 * @return bool
-	 */
-	public function afterSend( OrderSender $subject, $result, Order $order ) {
-		if ( $result && $this->shouldPreventEmail( $order ) && $this->config->isPluginEnabled() ) {
-			$this->logger->warning( 'Order email was sent despite prevention attempts for order: ' . $order->getIncrementId() );
-		}
-
-		return $result;
 	}
 }

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-Version : 2.3.3
-Updated : 12-01-2026
+Version : 2.3.4
+Updated : 25-06-2026


### PR DESCRIPTION
  - Security fix (Response.php): Order state was driven by the raw status param from the gateway's redirect POST (tamperable, CSRF
  disabled on this endpoint) — allowing a CHARGED value to be substituted for a real AUTHORIZATION_FAILED. Now all order-state
  decisions use the gateway-verified status from the OrderStatus API instead.
  - Added a fast-path for NEW status with no signature (no real payment attempt) — confirms via OrderStatus API directly.
  - Suspected Fraud handling: PaymentMethod::initialize() keeps new orders in pending_payment instead of letting Magento auto-flag
  them Suspected Fraud.
  - Fraud flags (IsFraudDetected/IsTransactionPending) now cleared once the gateway confirms CHARGED/COD_INITIATED.
  - Invoice creation and webhook processing extended to cover fraud-status orders.
  - StatusSync admin controller made self-contained (no longer delegates to base controller).
  - PreventOrderEmailPlugin generalized to cover invoice emails, not just order emails.